### PR TITLE
allow to get Clusterversion and support to specify source image

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: kata-operator
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
   - ""
   - machineconfiguration.openshift.io
   resources:  

--- a/pkg/apis/kataconfiguration/v1alpha1/kataconfig_types.go
+++ b/pkg/apis/kataconfiguration/v1alpha1/kataconfig_types.go
@@ -17,6 +17,8 @@ type KataConfigSpec struct {
 
 // KataInstallConfig is a placeholder struct
 type KataInstallConfig struct {
+	// SourceImage is the name of the kata-deploy image
+	SourceImage string `json:"sourceImage"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig


### PR DESCRIPTION
Two small patches to support other features

These patches are to allow the operator to get the clusterversion which we need to check if the kata SourceImage can work with the OCP version the cluster is using.  